### PR TITLE
Add Claude Code backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ai-cmd
 
-Zsh plugin to generate shell commands from natural language using local LLMs via ollama.
+Zsh plugin to generate shell commands from natural language using LLMs via [Claude Code](https://docs.anthropic.com/en/docs/claude-code) or [Ollama](https://ollama.ai/).
 
 ## Installation
 
@@ -30,14 +30,21 @@ echo 'source ~/.zsh/ai-cmd/ai-cmd.plugin.zsh' >> ~/.zshrc
 Set these environment variables **before** the plugin loads (before `source $ZSH/oh-my-zsh.sh`):
 
 ```bash
-# Command to run ollama (default: "ollama")
-export AI_CMD_OLLAMA_CMD="ollama"
-export AI_CMD_OLLAMA_CMD="podman exec systemd-ollama ollama"  # containerized
-export AI_CMD_OLLAMA_CMD="ssh server ollama"                   # remote
+# Backend to use: "ollama" or "claude" (default: "ollama")
+export AI_CMD_BACKEND="ollama"
+export AI_CMD_BACKEND="claude"
 
-# Model to use (default: "qwen2.5:7b")
-export AI_CMD_MODEL="qwen2.5:7b"
-export AI_CMD_MODEL="llama3.2:3b"
+# Ollama configuration
+export AI_CMD_OLLAMA_CMD="ollama"                          # default
+export AI_CMD_OLLAMA_CMD="podman exec systemd-ollama ollama"  # containerized
+export AI_CMD_OLLAMA_CMD="ssh server ollama"               # remote
+export AI_CMD_OLLAMA_MODEL="rnj-1:8b"                      # default
+export AI_CMD_OLLAMA_MODEL="llama3.2:3b"
+
+# Claude configuration
+export AI_CMD_CLAUDE_CMD="claude"                          # default
+export AI_CMD_CLAUDE_MODEL="sonnet"                        # optional
+export AI_CMD_CLAUDE_MODEL="opus"
 
 # Keybinding for ai-insert widget (default: "^[a" / Alt+a)
 export AI_CMD_KEYBINDING="^[a"   # Alt+a
@@ -85,8 +92,12 @@ ai show disk usage by directory | xclip -selection clipboard
 
 ## Requirements
 
-- [ollama](https://ollama.ai/) running locally or accessible via your configured command
-- A model pulled (e.g., `ollama pull qwen2.5:7b`)
+One of the following:
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated (`claude` CLI)
+- [Ollama](https://ollama.ai/) running locally or accessible via your configured command, with a model pulled (e.g., `ollama pull qwen2.5:7b`)
+
+The plugin defaults to Ollama. Set `AI_CMD_BACKEND=claude` to use Claude Code instead.
 
 ## License
 

--- a/ai-cmd.plugin.zsh
+++ b/ai-cmd.plugin.zsh
@@ -1,22 +1,27 @@
 # ai-cmd - Generate shell commands from natural language using LLMs
 #
 # Configuration (set before sourcing or in .zshrc):
-#   AI_CMD_OLLAMA_CMD    - Command to run ollama (default: "ollama")
-#   AI_CMD_MODEL         - Model to use (default: "qwen2.5:7b")
-#   AI_CMD_KEYBINDING    - Keybinding for ai-insert widget (default: "^[a" / Alt+a)
-#   AI_CMD_SYSTEM_PROMPT - Custom system prompt (optional)
+#   AI_CMD_BACKEND         - Backend to use: "ollama" or "claude" (default: "ollama")
+#   AI_CMD_OLLAMA_CMD      - Command to run Ollama (default: "ollama")
+#   AI_CMD_OLLAMA_MODEL    - Model for Ollama (default: "rnj-1:8b")
+#   AI_CMD_CLAUDE_CMD      - Command to run Claude (default: "claude")
+#   AI_CMD_CLAUDE_MODEL    - Model for Claude (optional, uses Claude Code default)
+#   AI_CMD_KEYBINDING      - Keybinding for ai-insert widget (default: "^[a" / Alt+a)
+#   AI_CMD_SYSTEM_PROMPT   - Custom system prompt (optional)
 #
 # Examples:
-#   export AI_CMD_OLLAMA_CMD="podman exec systemd-ollama ollama"
-#   export AI_CMD_OLLAMA_CMD="ollama"
-#   export AI_CMD_MODEL="llama3.2:3b"
+#   export AI_CMD_BACKEND="claude"
+#   export AI_CMD_CLAUDE_MODEL="sonnet"
+#
+#   export AI_CMD_BACKEND="ollama"
+#   export AI_CMD_OLLAMA_CMD="podman exec systemd-ollama ollama"  # containerized
+#   export AI_CMD_OLLAMA_MODEL="llama3.2:3b"
+#
 #   export AI_CMD_KEYBINDING="^[a"   # Alt+a (default)
 #   export AI_CMD_KEYBINDING="^xa"   # Ctrl+x, a
 #   export AI_CMD_KEYBINDING=""      # Disable keybinding
 
 # Defaults
-: ${AI_CMD_OLLAMA_CMD:="ollama"}
-: ${AI_CMD_MODEL:="qwen2.5:7b"}
 : ${AI_CMD_KEYBINDING:="^[a"}
 : ${AI_CMD_SYSTEM_PROMPT:="You are an AI terminal command generator.
 Your ONLY output must be valid POSIX shell commands.
@@ -25,17 +30,46 @@ Output only commands that a terminal can execute."}
 
 # Strip ANSI escape codes and carriage returns from output
 _ai_cmd_strip_ansi() {
-  sed $'s/\x1B\[[0-9;]*[a-zA-Z]//g; s/\x1B\[[?][0-9;]*[a-zA-Z]//g' | tr -d '\r'
+  sed $'s/\x1B\[[?]*[0-9;]*[a-zA-Z]//g' | tr -d '\r'
 }
+
+# Detect which backend to use
+_ai_cmd_detect_backend() {
+  if [[ -n "$AI_CMD_BACKEND" ]]; then
+    echo "$AI_CMD_BACKEND"
+  elif command -v ollama &>/dev/null; then
+    echo "ollama"
+  else
+    echo "none"
+  fi
+}
+
 
 # Run the LLM and get a command
 _ai_cmd_generate() {
   local prompt="$1"
-  local full_prompt="SYSTEM: $AI_CMD_SYSTEM_PROMPT
+  local backend=$(_ai_cmd_detect_backend)
+
+  case "$backend" in
+    claude)
+      local cmd="${AI_CMD_CLAUDE_CMD:-claude}"
+      local model_arg=""
+      [[ -n "$AI_CMD_CLAUDE_MODEL" ]] && model_arg="--model $AI_CMD_CLAUDE_MODEL"
+      eval "$cmd -p $model_arg \"\$AI_CMD_SYSTEM_PROMPT prompt: \$prompt\"" 2>/dev/null | _ai_cmd_strip_ansi
+      ;;
+    ollama)
+      local cmd="${AI_CMD_OLLAMA_CMD:-ollama}"
+      local model="${AI_CMD_OLLAMA_MODEL:-rnj-1:8b}"
+      local full_prompt="SYSTEM: $AI_CMD_SYSTEM_PROMPT
 
 USER: $prompt"
-
-  eval "$AI_CMD_OLLAMA_CMD run $AI_CMD_MODEL \"\$full_prompt\"" 2>/dev/null | _ai_cmd_strip_ansi
+      eval "$cmd run $model \"\$full_prompt\"" 2>/dev/null | _ai_cmd_strip_ansi
+      ;;
+    *)
+      echo "Error: No AI backend available. Install 'ollama' or set AI_CMD_BACKEND." >&2
+      return 1
+      ;;
+  esac
 }
 
 # Interactive function - call from command line


### PR DESCRIPTION
## Summary

- Adds support for Claude Code as an alternative backend to Ollama
- Introduces `AI_CMD_BACKEND` variable to select between "ollama" and "claude"
- Adds per-backend configuration: `AI_CMD_OLLAMA_CMD`, `AI_CMD_OLLAMA_MODEL`, `AI_CMD_CLAUDE_CMD`, `AI_CMD_CLAUDE_MODEL`
- Defaults to Ollama backend with `rnj-1:8b` model
- Improves ANSI escape code stripping for cleaner output

Closes #1

## Test plan

- [ ] Test with Ollama backend (default)
- [ ] Test with `AI_CMD_BACKEND=claude`
- [ ] Verify custom model selection works for both backends
- [ ] Test keybinding widget (Alt+a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)